### PR TITLE
Allow html that doesn't include a style tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,8 +29,9 @@ module.exports = function (html, options, callback) {
                 $(element).remove();
             }
         }
-
-        results.html = $.html();
     });
+
+    results.html = $.html();
+
     callback(null, results);
 };

--- a/test/expected/no-style-tag/out.html
+++ b/test/expected/no-style-tag/out.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" href="file.css">
+  </head>
+  <body>
+    <h1>Hi</h1>
+    <table>
+      <tr>
+        <td class="headline">Some Headline</td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/test/fixtures/no-style-tag/in.html
+++ b/test/fixtures/no-style-tag/in.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" href="file.css"/>
+  </head>
+  <body>
+    <h1>Hi</h1>
+    <table>
+      <tr>
+        <td class="headline">Some Headline</td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/test/main.js
+++ b/test/main.js
@@ -18,12 +18,12 @@ function getFile(filePath) {
     });
 }
 
-function compare(fixturePath, expectedHTML, options, done) {
+function compare(fixturePath, expectedHTML, css, options, done) {
     var file = getFile(fixturePath);
 
     getStylesData(file.contents.toString('utf8'), options, function (err, results) {
         results.html.should.be.equal(String(fs.readFileSync(expectedHTML)));
-        should.deepEqual(results.css, [ '\n      h1 {\n        border: 1px solid #ccc;\n      }\n    ' ]);
+        should.deepEqual(results.css, css);
         done();
     });
 }
@@ -35,6 +35,16 @@ describe('style-data', function() {
             removeStyleTags: true,
             preserveMediaQueries: false
         };
-        compare(path.join('test', 'fixtures', 'in.html'), path.join('test', 'expected', 'out.html'), options, done);
+        compare(path.join('test', 'fixtures', 'in.html'), path.join('test', 'expected', 'out.html'), [ '\n      h1 {\n        border: 1px solid #ccc;\n      }\n    ' ], options, done);
     });
+
+    it('Should leave html from no style html', function(done) {
+        var options = {
+            applyStyleTags: true,
+            removeStyleTags: true,
+            preserveMediaQueries: false
+        };
+        compare(path.join('test', 'fixtures', 'no-style-tag', 'in.html'), path.join('test', 'expected', 'no-style-tag', 'out.html'), [], options, done);
+    });
+
 });


### PR DESCRIPTION
I use gulp-inline-css.
It's a very useful. Thanks!

This pull request allows html that doesn't include a style tag.
(I'd like to write css code in css files only.)
