### PR TITLE
Remove style tag if empty. Added test for media query option.

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,8 @@ module.exports = function (html, options, callback) {
             if (options.preserveMediaQueries) {
                 mediaQueries = mediaQueryText(element.childNodes[0].nodeValue);
                 element.childNodes[0].nodeValue = mediaQueries;
-            } else {
+            }
+            if (!mediaQueries) {
                 $(element).remove();
             }
         }

--- a/test/expected/media-queries/out.html
+++ b/test/expected/media-queries/out.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    
+    <link rel="stylesheet" href="file.css">
+  </head>
+  <body>
+    <style>
+@media only screen and (min-width: 640px) {
+  .headline {
+    color: blue;
+  }
+}
+</style>
+    <h1>Hi</h1>
+    <table>
+      <tr>
+        <td class="headline">Some Headline</td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/test/fixtures/media-queries/in.html
+++ b/test/fixtures/media-queries/in.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      h1 {
+        border: 1px solid #ccc;
+      }
+    </style>
+    <link rel="stylesheet" href="file.css"/>
+  </head>
+  <body>
+    <style>
+      @media only screen and (min-width: 640px) {
+        .headline {
+          color: blue;
+        }
+      }
+    </style>
+    <h1>Hi</h1>
+    <table>
+      <tr>
+        <td class="headline">Some Headline</td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/test/main.js
+++ b/test/main.js
@@ -46,4 +46,12 @@ describe('style-data', function() {
         compare(path.join('test', 'fixtures', 'no-style-tag', 'in.html'), path.join('test', 'expected', 'no-style-tag', 'out.html'), [], options, done);
     });
 
+    it('Should leave style blocks if they contain media queries', function(done) {
+        var options = {
+            applyStyleTags: true,
+            removeStyleTags: true,
+            preserveMediaQueries: true
+        };
+        compare(path.join('test', 'fixtures', 'media-queries', 'in.html'), path.join('test', 'expected', 'media-queries', 'out.html'), [ '\n      h1 {\n        border: 1px solid #ccc;\n      }\n    ', '\n      @media only screen and (min-width: 640px) {\n        .headline {\n          color: blue;\n        }\n      }\n    '], options, done);
+    });
 });


### PR DESCRIPTION
When `preserveMediaQueries === true` and `removeStyleTags === true` no style tags are removed even if they don't contain media queries.