### PR TITLE
skip inlining/removing if data-embed attribute is present on style tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,6 +66,11 @@ module.exports = function (html, options, callback) {
     $('style').each(function (index, element) {
         var mediaQueries;
 
+        // if data-embed property exists, skip inlining and removing 
+        if(typeof $(element).data("embed") !== 'undefined') {
+            return;
+        }
+
         styleDataList = element.childNodes;
         if (styleDataList.length !== 1) {
             callback(new Error('empty style element'));

--- a/test/expected/data-embed/out.html
+++ b/test/expected/data-embed/out.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    
+    <link rel="stylesheet" href="file.css">
+  </head>
+  <body>
+    <style data-embed="">
+        .headline {
+          color: blue;
+        }
+    </style>
+    <style data-embed="">
+        .headline {
+          color: green;
+        }
+    </style>
+    <style data-embed="false">
+        .headline {
+          color: red;
+        }
+    </style>
+    <style data-embed="undefined">
+        .headline {
+          color: yellow;
+        }
+    </style>
+    <style data-embed="null">
+        .headline {
+          color: cyan;
+        }
+    </style>
+    <h1>Hi</h1>
+    <table>
+      <tr>
+        <td class="headline">Some Headline</td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/test/fixtures/data-embed/in.html
+++ b/test/fixtures/data-embed/in.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      h1 {
+        border: 1px solid #ccc;
+      }
+    </style>
+    <link rel="stylesheet" href="file.css"/>
+  </head>
+  <body>
+    <style data-embed>
+        .headline {
+          color: blue;
+        }
+    </style>
+    <style data-embed="">
+        .headline {
+          color: green;
+        }
+    </style>
+    <style data-embed="false">
+        .headline {
+          color: red;
+        }
+    </style>
+    <style data-embed="undefined">
+        .headline {
+          color: yellow;
+        }
+    </style>
+    <style data-embed="null">
+        .headline {
+          color: cyan;
+        }
+    </style>
+    <h1>Hi</h1>
+    <table>
+      <tr>
+        <td class="headline">Some Headline</td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/test/main.js
+++ b/test/main.js
@@ -121,4 +121,20 @@ describe('style-data', function () {
             done
         );
     });
+
+    it('Should ignore style blocks if data-embed attribute is present on them', function (done) {
+        var options = {
+            applyStyleTags: true,
+            removeStyleTags: true,
+            preserveMediaQueries: true
+        };
+
+        compare(
+            path.join('test', 'fixtures', 'data-embed', 'in.html'),
+            path.join('test', 'expected', 'data-embed', 'out.html'),
+            [ '\n      h1 {\n        border: 1px solid #ccc;\n      }\n    '],
+            options,
+            done
+        );
+    });
 });


### PR DESCRIPTION
As per issue #5, I implemented 3 lines of code into index.js where it checks if data-embed attribute exists, and skips rest of loop if it does. I also added tests for this functionality. 